### PR TITLE
Allow for simple validation without throwing an InvalidArgumentException

### DIFF
--- a/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
@@ -32,7 +32,7 @@ public final class ConfigurationValidator {
     private ConfigurationValidator() {}
 
     /**
-     * Validates the {code url} is a well formed HTTPS URL and does not contain common typos.  The checks include:
+     * Validates the {@code url} is a well formed HTTPS URL and does not contain common typos.  The checks include:
      * <ul>
      *     <li>Contains {yourOktaDomain}</li>
      *     <li>Hostname ends with .com.com</li>
@@ -42,37 +42,12 @@ public final class ConfigurationValidator {
      * </ul>
      * @param url The url to be validated
      */
-    public static void assertHttpsUrl(String url) {
-        validateHttpsUrl(url).ifInvalidThrow();
+    public static void assertOrgUrl(String url) {
+        validateOrgUrl(url).ifInvalidThrow();
     }
 
-    public static ValidationResponse validateHttpsUrl(String url) {
-
-        ValidationResponse response = new ValidationResponse();
-        if (!hasText(url)) {
-            response.setMessage(ERRORS.getString("orgUrl.missing"));
-        } else if (contains(url, "{yourOktaDomain}")) {
-            response.setMessage(ERRORS.getString("orgUrl.containsBrackets"));
-        } else {
-            try {
-                URL tempUrl = new URL(url);
-                if (!"https".equalsIgnoreCase(tempUrl.getProtocol())) {
-                    response.setMessage(formattedErrorMessage("orgUrl.nonHttpsInvalid", url));
-                } else if (tempUrl.getHost().endsWith(".com.com")){
-                    response.setMessage(formattedErrorMessage("orgUrl.invalid", url));
-                } else if (tempUrl.getHost().endsWith("-admin.okta.com")
-                           || tempUrl.getHost().endsWith("-admin.oktapreview.com")
-                           || tempUrl.getHost().endsWith("-admin.okta-emea.com")){
-                    response.setMessage(formattedErrorMessage("orgUrl.containsAdmin", url));
-                }
-
-            } catch (MalformedURLException e) {
-                response.setMessage(formattedErrorMessage("orgUrl.invalid", url))
-                        .setException(e);
-            }
-        }
-
-        return response;
+    public static ValidationResponse validateOrgUrl(String url) {
+        return validateHttpsUrl(url, "orgUrl");
     }
 
     /**
@@ -91,6 +66,25 @@ public final class ConfigurationValidator {
             response.setMessage(ERRORS.getString("apiToken.containsBrackets"));
         }
         return response;
+    }
+
+    /**
+     * Validates the {@code url} is a well formed HTTPS URL and does not contain common typos.  The checks include:
+     * <ul>
+     *     <li>Contains {yourOktaDomain}</li>
+     *     <li>Hostname ends with .com.com</li>
+     *     <li>Contains -admin.okta.com</li>
+     *     <li>Contains -admin.oktapreview.com</li>
+     *     <li>Contains -admin.okta-emea.com</li>
+     * </ul>
+     * @param url The url to be validated
+     */
+    public static void assertIssuer(String url) {
+        validateIssuer(url).ifInvalidThrow();
+    }
+
+    public static ValidationResponse validateIssuer(String url) {
+        return validateHttpsUrl(url, "issuerUrl");
     }
 
     /**
@@ -132,6 +126,34 @@ public final class ConfigurationValidator {
     private static String formattedErrorMessage(String messageKey, Object... args) {
         String message = ERRORS.getString(messageKey);
         return MessageFormat.format(message, args);
+    }
+
+    private static ValidationResponse validateHttpsUrl(String url, String keyPrefix) {
+        ValidationResponse response = new ValidationResponse();
+        if (!hasText(url)) {
+            response.setMessage(ERRORS.getString(keyPrefix + ".missing"));
+        } else if (contains(url, "{yourOktaDomain}")) {
+            response.setMessage(ERRORS.getString(keyPrefix + ".containsBrackets"));
+        } else {
+            try {
+                URL tempUrl = new URL(url);
+                if (!"https".equalsIgnoreCase(tempUrl.getProtocol())) {
+                    response.setMessage(formattedErrorMessage(keyPrefix + ".nonHttpsInvalid", url));
+                } else if (tempUrl.getHost().endsWith(".com.com")){
+                    response.setMessage(formattedErrorMessage(keyPrefix + ".invalid", url));
+                } else if (tempUrl.getHost().endsWith("-admin.okta.com")
+                           || tempUrl.getHost().endsWith("-admin.oktapreview.com")
+                           || tempUrl.getHost().endsWith("-admin.okta-emea.com")){
+                    response.setMessage(formattedErrorMessage(keyPrefix + ".containsAdmin", url));
+                }
+
+            } catch (MalformedURLException e) {
+                response.setMessage(formattedErrorMessage(keyPrefix + ".invalid", url))
+                        .setException(e);
+            }
+        }
+
+        return response;
     }
 
     /*

--- a/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
@@ -43,7 +43,7 @@ public final class ConfigurationValidator {
      * @param url The url to be validated
      */
     public static void assertHttpsUrl(String url) {
-        validateHttpsUrl(url).throwIfInvalid();
+        validateHttpsUrl(url).ifInvalidThrow();
     }
 
     public static ValidationResponse validateHttpsUrl(String url) {
@@ -80,7 +80,7 @@ public final class ConfigurationValidator {
      * @param token The API Token to be validated
      */
     public static void assertApiToken(String token) {
-        validateApiToken(token).throwIfInvalid();
+        validateApiToken(token).ifInvalidThrow();
     }
 
     public static ValidationResponse validateApiToken(String token) {
@@ -98,7 +98,7 @@ public final class ConfigurationValidator {
      * @param clientId The Client Id to be validated
      */
     public static void assertClientId(String clientId) {
-        validateClientId(clientId).throwIfInvalid();
+        validateClientId(clientId).ifInvalidThrow();
     }
 
     public static ValidationResponse validateClientId(String clientId) {
@@ -116,7 +116,7 @@ public final class ConfigurationValidator {
      * @param clientSecret the Client Secret to be validated
      */
     public static void assertClientSecret(String clientSecret) {
-        validateClientSecret(clientSecret).throwIfInvalid();
+        validateClientSecret(clientSecret).ifInvalidThrow();
     }
 
     public static ValidationResponse validateClientSecret(String clientSecret) {

--- a/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
@@ -20,6 +20,8 @@ import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
 
+import static java.util.Locale.ENGLISH;
+
 /**
  * Configuration validation helper class to help validation of common configuration strings.
  *
@@ -62,7 +64,7 @@ public final class ConfigurationValidator {
         ValidationResponse response = new ValidationResponse();
         if (!hasText(token)) {
             response.setMessage(ERRORS.getString("apiToken.missing"));
-        } else if (contains(token, "{apiToken}")) {
+        } else if (containsCaseInsensitive(token, "{apitoken}")) {
             response.setMessage(ERRORS.getString("apiToken.containsBrackets"));
         }
         return response;
@@ -99,7 +101,7 @@ public final class ConfigurationValidator {
         ValidationResponse response = new ValidationResponse();
         if (!hasText(clientId)) {
             response.setMessage(ERRORS.getString("clientId.missing"));
-        } else if (contains(clientId, "{clientId}")) {
+        } else if (containsCaseInsensitive(clientId, "{clientid}")) {
             response.setMessage(ERRORS.getString("clientId.containsBrackets"));
         }
         return response;
@@ -117,7 +119,7 @@ public final class ConfigurationValidator {
         ValidationResponse response = new ValidationResponse();
         if (!hasText(clientSecret)) {
             response.setMessage(ERRORS.getString("clientSecret.missing"));
-        } else if (contains(clientSecret, "{clientSecret}")) {
+        } else if (containsCaseInsensitive(clientSecret, "{clientsecret}")) {
             response.setMessage(ERRORS.getString("clientSecret.containsBrackets"));
         }
         return response;
@@ -132,21 +134,21 @@ public final class ConfigurationValidator {
         ValidationResponse response = new ValidationResponse();
         if (!hasText(url)) {
             response.setMessage(ERRORS.getString(keyPrefix + ".missing"));
-        } else if (contains(url, "{yourOktaDomain}")) {
+        } else if (containsCaseInsensitive(url, "{youroktadomain}")) {
             response.setMessage(ERRORS.getString(keyPrefix + ".containsBrackets"));
         } else {
             try {
                 URL tempUrl = new URL(url);
+                String host = tempUrl.getHost().toLowerCase(ENGLISH);
                 if (!"https".equalsIgnoreCase(tempUrl.getProtocol())) {
                     response.setMessage(formattedErrorMessage(keyPrefix + ".nonHttpsInvalid", url));
-                } else if (tempUrl.getHost().endsWith(".com.com")){
+                } else if (host.endsWith(".com.com")){
                     response.setMessage(formattedErrorMessage(keyPrefix + ".invalid", url));
-                } else if (tempUrl.getHost().endsWith("-admin.okta.com")
-                           || tempUrl.getHost().endsWith("-admin.oktapreview.com")
-                           || tempUrl.getHost().endsWith("-admin.okta-emea.com")){
-                    response.setMessage(formattedErrorMessage(keyPrefix + ".containsAdmin", url));
+                } else if (host.endsWith("-admin.okta.com")
+                        || host.endsWith("-admin.oktapreview.com")
+                        || host.endsWith("-admin.okta-emea.com")){
+                        response.setMessage(formattedErrorMessage(keyPrefix + ".containsAdmin", url));
                 }
-
             } catch (MalformedURLException e) {
                 response.setMessage(formattedErrorMessage(keyPrefix + ".invalid", url))
                         .setException(e);
@@ -160,10 +162,10 @@ public final class ConfigurationValidator {
      *  private methods copied from com.okta.sdk.lang.Assert, can be updated if we pull that out of the SDK project
      */
 
-    private static boolean contains(String textToSearch, String substring) {
+    private static boolean containsCaseInsensitive(String textToSearch, String substring) {
         return hasLength(textToSearch)
                 && hasLength(substring)
-                && textToSearch.contains(substring);
+                && textToSearch.toLowerCase(ENGLISH).contains(substring);
     }
 
     private static boolean hasText(CharSequence str) {

--- a/config-check/src/main/java/com/okta/commons/configcheck/ValidationResponse.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ValidationResponse.java
@@ -41,9 +41,6 @@ public class ValidationResponse {
 
     public void ifInvalidThrow() {
         ifInvalid(res -> {
-            if (exception == null) {
-                throw new IllegalArgumentException(message);
-            }
             throw new IllegalArgumentException(message, exception);
         });
     }

--- a/config-check/src/main/java/com/okta/commons/configcheck/ValidationResponse.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ValidationResponse.java
@@ -15,11 +15,15 @@
  */
 package com.okta.commons.configcheck;
 
+import java.util.function.Consumer;
+
 public class ValidationResponse {
 
     private boolean valid = true;
     private String message;
     private Exception exception;
+
+    ValidationResponse() {}
 
     public boolean isValid() {
         return valid;
@@ -35,12 +39,18 @@ public class ValidationResponse {
         return this;
     }
 
-    public void throwIfInvalid() {
-        if (!valid) {
+    public void ifInvalidThrow() {
+        ifInvalid(res -> {
             if (exception == null) {
                 throw new IllegalArgumentException(message);
             }
             throw new IllegalArgumentException(message, exception);
+        });
+    }
+
+    public void ifInvalid(Consumer<ValidationResponse> consumer) {
+        if (!valid) {
+            consumer.accept(this);
         }
     }
 
@@ -53,7 +63,7 @@ public class ValidationResponse {
         return this;
     }
 
-    public static ValidationResponse valid() {
+    static ValidationResponse valid() {
         return new ValidationResponse();
     }
 }

--- a/config-check/src/main/java/com/okta/commons/configcheck/ValidationResponse.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ValidationResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.commons.configcheck;
+
+public class ValidationResponse {
+
+    private boolean valid = true;
+    private String message;
+    private Exception exception;
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public ValidationResponse setMessage(String message) {
+        this.message = message;
+        this.valid = false;
+        return this;
+    }
+
+    public void throwIfInvalid() {
+        if (!valid) {
+            if (exception == null) {
+                throw new IllegalArgumentException(message);
+            }
+            throw new IllegalArgumentException(message, exception);
+        }
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    public ValidationResponse setException(Exception exception) {
+        this.exception = exception;
+        return this;
+    }
+
+    public static ValidationResponse valid() {
+        return new ValidationResponse();
+    }
+}

--- a/config-check/src/main/resources/com/okta/commons/configcheck/ConfigurationValidator.properties
+++ b/config-check/src/main/resources/com/okta/commons/configcheck/ConfigurationValidator.properties
@@ -23,6 +23,12 @@ orgUrl.containsAdmin=Your Okta domain should not contain -admin. Current value: 
 apiToken.missing=Your Okta API token is missing. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token
 apiToken.containsBrackets=Replace {apiToken} with your Okta API token. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token
 
+issuerUrl.missing=Your Okta Issuer URL is missing. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain
+issuerUrl.invalid=It looks like there''s a typo in your Okta Issuer URL. Current value: {0}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain
+issuerUrl.nonHttpsInvalid=Your Okta Issuer URL must start with https. Current value: {0}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain
+issuerUrl.containsBrackets=Replace {yourOktaDomain} with your Okta domain. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain
+issuerUrl.containsAdmin=Your Okta Issuer URL should not contain -admin. Current value: {0}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain
+
 clientId.missing=Your client ID is missing. You can copy it from the Okta Developer Console in the details for the Application you created. Follow these instructions to find it: https://bit.ly/finding-okta-app-credentials
 clientId.containsBrackets=Replace {clientId} with the client ID of your Application. You can copy it from the Okta Developer Console in the details for the Application you created. Follow these instructions to find it: https://bit.ly/finding-okta-app-credentials
 

--- a/config-check/src/main/resources/com/okta/commons/configcheck/ConfigurationValidator.properties
+++ b/config-check/src/main/resources/com/okta/commons/configcheck/ConfigurationValidator.properties
@@ -21,7 +21,7 @@ orgUrl.containsBrackets=Replace {yourOktaDomain} with your Okta domain. You can 
 orgUrl.containsAdmin=Your Okta domain should not contain -admin. Current value: {0}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain
 
 apiToken.missing=Your Okta API token is missing. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token
-apiToken.invalid=Replace {apiToken} with your Okta API token. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token
+apiToken.containsBrackets=Replace {apiToken} with your Okta API token. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token
 
 clientId.missing=Your client ID is missing. You can copy it from the Okta Developer Console in the details for the Application you created. Follow these instructions to find it: https://bit.ly/finding-okta-app-credentials
 clientId.containsBrackets=Replace {clientId} with the client ID of your Application. You can copy it from the Okta Developer Console in the details for the Application you created. Follow these instructions to find it: https://bit.ly/finding-okta-app-credentials

--- a/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
+++ b/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
@@ -86,6 +86,9 @@ class ConfigurationValidatorTest {
     void bracketApiToken() {
         def e = expect {ConfigurationValidator.assertApiToken("{apiToken}")}
         assertThat(e.message, containsString("Replace {apiToken} with your Okta API token"))
+
+        e = expect {ConfigurationValidator.assertApiToken("{aPiToKeN}")}
+        assertThat(e.message, containsString("Replace {apiToken} with your Okta API token"))
     }
 
     @Test
@@ -105,11 +108,18 @@ class ConfigurationValidatorTest {
         def e = expect {ConfigurationValidator.assertIssuer("http://okta.example.com/oauth/default")}
         assertThat(e.message, allOf(containsString("Your Okta Issuer URL must start with https"),
                                    containsString("http://okta.example.com")))
+
+        e = expect {ConfigurationValidator.assertIssuer("HTTP://okta.example.com/oauth/default")}
+        assertThat(e.message, allOf(containsString("Your Okta Issuer URL must start with https"),
+                                   containsString("HTTP://okta.example.com")))
     }
 
     @Test
     void bracketIssuerUrl() {
         def e = expect {ConfigurationValidator.assertIssuer("https://{yourOktaDomain}/oauth/default")}
+        assertThat(e.message, containsString("Replace {yourOktaDomain} with your Okta domain"))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://{yOurOkTaDoMaIn}/oauth/default")}
         assertThat(e.message, containsString("Replace {yourOktaDomain} with your Okta domain"))
     }
 
@@ -122,7 +132,10 @@ class ConfigurationValidatorTest {
         e = expect {ConfigurationValidator.assertIssuer("https://example-admin.oktapreview.com/oauth/default")}
         assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
 
-         e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta-emea.com/oauth/default")}
+        e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta-emea.com/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://example-aDmIn.okTa-emea.com/oauth/default")}
         assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
     }
 
@@ -132,8 +145,13 @@ class ConfigurationValidatorTest {
         assertThat(e.message, allOf(containsString("It looks like there's a typo in your Okta Issuer URL"),
                                    containsString("https://okta.example.com.com/oauth/default")))
 
+        e = expect {ConfigurationValidator.assertIssuer("https://okta.example.cOm.CoM/oauth/default")}
+        assertThat(e.message, allOf(containsString("It looks like there's a typo in your Okta Issuer URL"),
+                                   containsString("https://okta.example.cOm.CoM/oauth/default")))
+
         // this line should NOT throw
         ConfigurationValidator.assertIssuer("https://example.com.commercial.com")
+        ConfigurationValidator.assertIssuer("https://example.COM.commercial.com")
         // xcomxcom would match a regex, so make sure we are matching exactly
         ConfigurationValidator.assertIssuer("https://okta.examplexcomxcom/oauth/default")
     }
@@ -154,6 +172,9 @@ class ConfigurationValidatorTest {
     @Test
     void bracketClientId() {
         def e = expect {ConfigurationValidator.assertClientId("{clientId}")}
+        assertThat(e.message, containsString("Replace {clientId} with the client ID of your Application"))
+
+        e = expect {ConfigurationValidator.assertClientId("{cLiEntId}")}
         assertThat(e.message, containsString("Replace {clientId} with the client ID of your Application"))
     }
 
@@ -179,6 +200,9 @@ class ConfigurationValidatorTest {
     @Test
     void bracketClientSecret() {
         def e = expect {ConfigurationValidator.assertClientSecret("{clientSecret}")}
+        assertThat(e.message, containsString("Replace {clientSecret} with the client secret of your Application"))
+
+        e = expect {ConfigurationValidator.assertClientSecret("{ClIeNtSeCrEt}")}
         assertThat(e.message, containsString("Replace {clientSecret} with the client secret of your Application"))
     }
 

--- a/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
+++ b/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
@@ -30,104 +30,104 @@ class ConfigurationValidatorTest {
     
     @Test
     void nullBaseUrl() {
-        def e = expect {ConfigurationValidator.validateHttpsUrl(null)}
+        def e = expect {ConfigurationValidator.assertHttpsUrl(null)}
         assertThat(e.message,containsString("Your Okta URL is missing"))
     }
 
     @Test
     void httpBaseUrl() {
-        def e = expect {ConfigurationValidator.validateHttpsUrl("http://okta.example.com")}
+        def e = expect {ConfigurationValidator.assertHttpsUrl("http://okta.example.com")}
         assertThat(e.message, allOf(containsString("Your Okta URL must start with https"),
                                    containsString("http://okta.example.com")))
     }
 
     @Test
     void bracketBaseUrl() {
-        def e = expect {ConfigurationValidator.validateHttpsUrl("https://{yourOktaDomain}")}
+        def e = expect {ConfigurationValidator.assertHttpsUrl("https://{yourOktaDomain}")}
         assertThat(e.message, containsString("Replace {yourOktaDomain} with your Okta domain"))
     }
 
     @Test
     void adminBaseUrl() {
-        def e = expect {ConfigurationValidator.validateHttpsUrl("https://example-admin.okta.com")}
+        def e = expect {ConfigurationValidator.assertHttpsUrl("https://example-admin.okta.com")}
         assertThat(e.message, allOf(containsString("Your Okta domain should not contain -admin"),
                                    containsString("https://example-admin.okta.com")))
 
-        e = expect {ConfigurationValidator.validateHttpsUrl("https://example-admin.oktapreview.com")}
+        e = expect {ConfigurationValidator.assertHttpsUrl("https://example-admin.oktapreview.com")}
         assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
 
-         e = expect {ConfigurationValidator.validateHttpsUrl("https://example-admin.okta-emea.com")}
+         e = expect {ConfigurationValidator.assertHttpsUrl("https://example-admin.okta-emea.com")}
         assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
     }
 
     @Test
     void doubleComBaseUrl() {
-        def e = expect {ConfigurationValidator.validateHttpsUrl("https://okta.example.com.com")}
+        def e = expect {ConfigurationValidator.assertHttpsUrl("https://okta.example.com.com")}
         assertThat(e.message, allOf(containsString("It looks like there's a typo in your Okta domain"),
                                    containsString("https://okta.example.com.com")))
 
-        e = expect {ConfigurationValidator.validateHttpsUrl("https://okta.example.com.com/some/path")}
+        e = expect {ConfigurationValidator.assertHttpsUrl("https://okta.example.com.com/some/path")}
         assertThat(e.message, containsString("It looks like there's a typo in your Okta domain"))
 
         // this line should NOT throw
-        ConfigurationValidator.validateHttpsUrl("https://example.com.commercial.com")
+        ConfigurationValidator.assertHttpsUrl("https://example.com.commercial.com")
         // xcomxcom would match a regex, so make sure we are matching exactly
-        ConfigurationValidator.validateHttpsUrl("https://okta.examplexcomxcom/some/path")
+        ConfigurationValidator.assertHttpsUrl("https://okta.examplexcomxcom/some/path")
     }
 
     @Test
     void nullApiToken() {
-        def e = expect {ConfigurationValidator.validateApiToken(null)}
+        def e = expect {ConfigurationValidator.assertApiToken(null)}
         assertThat(e.message, containsString("Your Okta API token is missing"))
     }
 
     @Test
     void bracketApiToken() {
-        def e = expect {ConfigurationValidator.validateApiToken("{apiToken}")}
+        def e = expect {ConfigurationValidator.assertApiToken("{apiToken}")}
         assertThat(e.message, containsString("Replace {apiToken} with your Okta API token"))
     }
 
     @Test
     void validApiToken() {
         // just make sure it doesn't throw
-        ConfigurationValidator.validateApiToken("some-other-text")
+        ConfigurationValidator.assertApiToken("some-other-text")
     }
 
     @Test
     void nullClientId() {
-        def e = expect {ConfigurationValidator.validateClientId(null)}
+        def e = expect {ConfigurationValidator.assertClientId(null)}
         assertThat(e.message, containsString("Your client ID is missing"))
     }
 
     @Test
     void bracketClientId() {
-        def e = expect {ConfigurationValidator.validateClientId("{clientId}")}
+        def e = expect {ConfigurationValidator.assertClientId("{clientId}")}
         assertThat(e.message, containsString("Replace {clientId} with the client ID of your Application"))
     }
 
     @Test
     void validClientId() {
         // just make sure it doesn't throw
-        ConfigurationValidator.validateClientId("some-other-text")
+        ConfigurationValidator.assertClientId("some-other-text")
     }
 
 
     @Test
     void nullClientSecret() {
-        def e = expect {ConfigurationValidator.validateClientSecret(null)}
+        def e = expect {ConfigurationValidator.assertClientSecret(null)}
         assertThat(e.message, containsString("Your client secret is missing"))
     }
 
     @Test
     void bracketClientSecret() {
-        def e = expect {ConfigurationValidator.validateClientSecret("{clientSecret}")}
+        def e = expect {ConfigurationValidator.assertClientSecret("{clientSecret}")}
         assertThat(e.message, containsString("Replace {clientSecret} with the client secret of your Application"))
     }
 
     @Test
     void validClientSecret() {
         // just make sure it doesn't throw
-        ConfigurationValidator.validateClientSecret("some-other-text")
+        ConfigurationValidator.assertClientSecret("some-other-text")
     }
     
     static def expect = { Closure callMe ->

--- a/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
+++ b/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
@@ -18,6 +18,8 @@ package com.okta.commons.configcheck
 import org.testng.Assert
 import org.testng.annotations.Test
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.allOf
 import static org.hamcrest.Matchers.both
@@ -100,6 +102,13 @@ class ConfigurationValidatorTest {
     }
 
     @Test
+    void nullClientIdFunctional() {
+        AtomicBoolean result = new AtomicBoolean(true)
+        ConfigurationValidator.validateClientId(null).ifInvalid({result.set(it.isValid())})
+        assertThat("ifInvalid did not call consumer", !result.get())
+    }
+
+    @Test
     void bracketClientId() {
         def e = expect {ConfigurationValidator.assertClientId("{clientId}")}
         assertThat(e.message, containsString("Replace {clientId} with the client ID of your Application"))
@@ -111,6 +120,12 @@ class ConfigurationValidatorTest {
         ConfigurationValidator.assertClientId("some-other-text")
     }
 
+    @Test
+    void functionalValidClientId() {
+        AtomicBoolean result = new AtomicBoolean(true)
+        ConfigurationValidator.validateClientId("some-client-id").ifInvalid({result.set(it.isValid())})
+        assertThat("ifInvalid called the consumer, and should not have been with a valid clientId", result.get())
+    }
 
     @Test
     void nullClientSecret() {

--- a/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
+++ b/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.allOf
-import static org.hamcrest.Matchers.both
 import static org.hamcrest.Matchers.containsString
 
 /**
@@ -32,49 +31,49 @@ class ConfigurationValidatorTest {
     
     @Test
     void nullBaseUrl() {
-        def e = expect {ConfigurationValidator.assertHttpsUrl(null)}
+        def e = expect {ConfigurationValidator.assertOrgUrl(null)}
         assertThat(e.message,containsString("Your Okta URL is missing"))
     }
 
     @Test
     void httpBaseUrl() {
-        def e = expect {ConfigurationValidator.assertHttpsUrl("http://okta.example.com")}
+        def e = expect {ConfigurationValidator.assertOrgUrl("http://okta.example.com")}
         assertThat(e.message, allOf(containsString("Your Okta URL must start with https"),
                                    containsString("http://okta.example.com")))
     }
 
     @Test
     void bracketBaseUrl() {
-        def e = expect {ConfigurationValidator.assertHttpsUrl("https://{yourOktaDomain}")}
+        def e = expect {ConfigurationValidator.assertOrgUrl("https://{yourOktaDomain}")}
         assertThat(e.message, containsString("Replace {yourOktaDomain} with your Okta domain"))
     }
 
     @Test
     void adminBaseUrl() {
-        def e = expect {ConfigurationValidator.assertHttpsUrl("https://example-admin.okta.com")}
+        def e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.okta.com")}
         assertThat(e.message, allOf(containsString("Your Okta domain should not contain -admin"),
                                    containsString("https://example-admin.okta.com")))
 
-        e = expect {ConfigurationValidator.assertHttpsUrl("https://example-admin.oktapreview.com")}
+        e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.oktapreview.com")}
         assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
 
-         e = expect {ConfigurationValidator.assertHttpsUrl("https://example-admin.okta-emea.com")}
+         e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.okta-emea.com")}
         assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
     }
 
     @Test
     void doubleComBaseUrl() {
-        def e = expect {ConfigurationValidator.assertHttpsUrl("https://okta.example.com.com")}
+        def e = expect {ConfigurationValidator.assertOrgUrl("https://okta.example.com.com")}
         assertThat(e.message, allOf(containsString("It looks like there's a typo in your Okta domain"),
                                    containsString("https://okta.example.com.com")))
 
-        e = expect {ConfigurationValidator.assertHttpsUrl("https://okta.example.com.com/some/path")}
+        e = expect {ConfigurationValidator.assertOrgUrl("https://okta.example.com.com/some/path")}
         assertThat(e.message, containsString("It looks like there's a typo in your Okta domain"))
 
         // this line should NOT throw
-        ConfigurationValidator.assertHttpsUrl("https://example.com.commercial.com")
+        ConfigurationValidator.assertOrgUrl("https://example.com.commercial.com")
         // xcomxcom would match a regex, so make sure we are matching exactly
-        ConfigurationValidator.assertHttpsUrl("https://okta.examplexcomxcom/some/path")
+        ConfigurationValidator.assertOrgUrl("https://okta.examplexcomxcom/some/path")
     }
 
     @Test
@@ -93,6 +92,50 @@ class ConfigurationValidatorTest {
     void validApiToken() {
         // just make sure it doesn't throw
         ConfigurationValidator.assertApiToken("some-other-text")
+    }
+
+     @Test
+    void nullIssuerUrl() {
+        def e = expect {ConfigurationValidator.assertIssuer(null)}
+        assertThat(e.message,containsString("Your Okta Issuer URL is missing"))
+    }
+
+    @Test
+    void httpIssuerUrl() {
+        def e = expect {ConfigurationValidator.assertIssuer("http://okta.example.com/oauth/default")}
+        assertThat(e.message, allOf(containsString("Your Okta Issuer URL must start with https"),
+                                   containsString("http://okta.example.com")))
+    }
+
+    @Test
+    void bracketIssuerUrl() {
+        def e = expect {ConfigurationValidator.assertIssuer("https://{yourOktaDomain}/oauth/default")}
+        assertThat(e.message, containsString("Replace {yourOktaDomain} with your Okta domain"))
+    }
+
+    @Test
+    void adminIssuerUrl() {
+        def e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta.com/oauth/default")}
+        assertThat(e.message, allOf(containsString("Your Okta Issuer URL should not contain -admin"),
+                                   containsString("https://example-admin.okta.com/oauth/default")))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://example-admin.oktapreview.com/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+
+         e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta-emea.com/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+    }
+
+    @Test
+    void doubleComIssuerUrl() {
+        def e = expect {ConfigurationValidator.assertIssuer("https://okta.example.com.com/oauth/default")}
+        assertThat(e.message, allOf(containsString("It looks like there's a typo in your Okta Issuer URL"),
+                                   containsString("https://okta.example.com.com/oauth/default")))
+
+        // this line should NOT throw
+        ConfigurationValidator.assertIssuer("https://example.com.commercial.com")
+        // xcomxcom would match a regex, so make sure we are matching exactly
+        ConfigurationValidator.assertIssuer("https://okta.examplexcomxcom/oauth/default")
     }
 
     @Test


### PR DESCRIPTION
This allows the ConfigurationValidator to be plugged into other frameworks such as a
Spring's Validator or a custom javax validation framework

Spring Validator example:

```java
public class OktaOAuth2PropertiesValidator implements Validator {

    @Override
    public boolean supports(Class<?> clazz) {
        return OktaOAuth2Properties.class.isAssignableFrom(clazz);
    }

    @Override
    public void validate(Object target, Errors errors) {

        OktaOAuth2Properties properties = (OktaOAuth2Properties) target;

        ConfigurationValidator.validateHttpsUrl(properties.getIssuer()).ifInvalid(res ->
            errors.rejectValue("issuer", res.getMessage()));

        ConfigurationValidator.validateClientId(properties.getIssuer()).ifInvalid(res ->
            errors.rejectValue("clientId", res.getMessage()));

        ConfigurationValidator.validateClientSecret(properties.getIssuer()).ifInvalid(res ->
            errors.rejectValue("clientSecret", res.getMessage()));
    }
}
```