### PR TITLE
Use TestNG version from dependencyManagement

### DIFF
--- a/http/http-api/pom.xml
+++ b/http/http-api/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.9.10</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.9.10</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/lang/src/test/groovy/com/okta/commons/lang/ApplicationInfoTest.groovy
+++ b/lang/src/test/groovy/com/okta/commons/lang/ApplicationInfoTest.groovy
@@ -42,7 +42,7 @@ class ApplicationInfoTest {
 
         def info = appInfo.getFullEntryStringUsingManifest(Test.class.getName(), "testng")
         assertThat info.name, is("testng")
-        assertThat info.version, is("6.9.10") // tied to version in pom.xml
+        assertThat info.version, is("7.0.0") // tied to version in pom.xml
 
         info = appInfo.getFullEntryStringUsingManifest(Mockito.class.getName(), "mockito")
         assertThat info.name, is("mockito")


### PR DESCRIPTION
These project was pulled into this module, so they still had a set TestNG version