### PR TITLE
Reserve automatic module name in the MANIFEST

### DIFF
--- a/config-check/pom.xml
+++ b/config-check/pom.xml
@@ -28,6 +28,10 @@
     <name>Okta Commons :: Config Check</name>
     <description>Provides utility classes to validate common configuration, base URLs, API token strings, etc.</description>
 
+    <properties>
+        <module.name>com.okta.commons.configcheck</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/http/http-api/pom.xml
+++ b/http/http-api/pom.xml
@@ -29,6 +29,10 @@
     <name>Okta Commons :: HTTP :: API</name>
     <description>Provides a common HTTP Interface for Okta's Java libraries</description>
 
+    <properties>
+        <module.name>com.okta.commons.http</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.okta.commons</groupId>

--- a/http/httpclient/pom.xml
+++ b/http/httpclient/pom.xml
@@ -34,6 +34,11 @@
         any time without warning - use it with runtime scope only.
     </description>
     <packaging>jar</packaging>
+
+    <properties>
+        <module.name>com.okta.commons.http.httpclient</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.okta.commons</groupId>

--- a/http/okhttp/pom.xml
+++ b/http/okhttp/pom.xml
@@ -35,6 +35,10 @@
     </description>
     <packaging>jar</packaging>
 
+    <properties>
+        <module.name>com.okta.commons.http.okhttp</module.name>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -29,6 +29,7 @@
     <description>Provides utility classes for common functionality (with no dependencies like Spring, Guava or Apache Commons.</description>
 
     <properties>
+        <module.name>com.okta.commons.lang</module.name>
         <powermock.version>2.0.2</powermock.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,17 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
By default, the file name is used (which isn't always consistent), setting the manifest entry reserves the module name if/when we use JPMS, and allows downstream consumers to have a consistent module name