### PR TITLE
Upgrade to httpclient5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2.1
+
+aliases:
+
+  - &build_steps
+    - checkout
+    - run: java -version
+    - run: ./mvnw clean install -Pci
+
+jobs:
+  
+  jdk8:
+    docker:
+      - image: cimg/openjdk:8.0.322
+    environment:
+        JVM_OPTS: -Xmx3200m
+    steps: *build_steps
+  
+  jdk11:
+    docker:
+      - image: cimg/openjdk:11.0.13
+    environment:
+        JVM_OPTS: -Xmx3200m
+    steps: *build_steps
+          
+  jdk18:
+    docker:
+      - image: cimg/openjdk:18.0.2
+    environment:
+        JVM_OPTS: -Xmx3200m
+    steps: *build_steps
+
+workflows:
+  build_and_test:
+    jobs:
+      - jdk8
+      - jdk11
+      - jdk18

--- a/http/httpclient/pom.xml
+++ b/http/httpclient/pom.xml
@@ -45,21 +45,21 @@
             <artifactId>okta-http-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
             <version>4.5.13</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                   <groupId>commons-logging</groupId>
+                   <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Runtime dependency to replace commons-logging needed by HTTPClient: -->
         <dependency>


### PR DESCRIPTION
`org.apache.httpcomponents.httpclient` has moved to `org.apache.httpcomponents.client5.httpclient5`

Ref: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient