### PR TITLE
fix cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-jvm</artifactId>
+                <version>3.2.0</version>
+            </dependency>
+
+            <dependency>
                 <!-- compile time annotation processor -->
                 <groupId>com.google.auto.service</groupId>
                 <artifactId>auto-service</artifactId>


### PR DESCRIPTION
`com.squareup.okhttp3:okhttp:jar:4.10.0` pulls in old version `3.0.0` that contains a CVE.

```
[INFO] +- com.okta.commons:okta-http-okhttp:jar:1.3.2-SNAPSHOT:compile
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:4.10.0:compile
[INFO] |  |  +- com.squareup.okio:okio-jvm:jar:3.0.0:compile
[INFO] |  |  |  +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.31:compile
[INFO] |  |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.31:compile
[INFO] |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.7.20:compile
[INFO] |  |  \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.7.20:compile
[INFO] |  |     \- org.jetbrains:annotations:jar:13.0:compile
[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.36:compile
```

We want to bring in the latest - https://mvnrepository.com/artifact/com.squareup.okio/okio-jvm/3.2.0