### PR TITLE
Java 17 instead of Java 18 in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ jobs:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
           
-  jdk18:
+  jdk17:
     docker:
-      - image: cimg/openjdk:18.0.2
+      - image: cimg/openjdk:17.0.4
     environment:
         JVM_OPTS: -Xmx3200m
     steps: *build_steps
@@ -35,4 +35,4 @@ workflows:
     jobs:
       - jdk8
       - jdk11
-      - jdk18
+      - jdk17


### PR DESCRIPTION
It is best to check if build works with LTS (Long Term Support) Java versions only.

Ref: https://endoflife.date/java