### PR TITLE
Fixed regex and corresponding test case

### DIFF
--- a/http/http-api/src/main/java/com/okta/commons/http/HttpHeaders.java
+++ b/http/http-api/src/main/java/com/okta/commons/http/HttpHeaders.java
@@ -515,13 +515,14 @@ public class HttpHeaders implements MultiValueMap<String, String> {
             List<String> headerValues = headers.get(LINK);
             return headerValues.stream()
                     .map(HttpHeaders::parseLinkHeader)
+                    .filter(link -> link != null)
                     .collect(Collectors.toMap(Link::getRelationType, Link::getHref));
         }
         return Collections.emptyMap();
     }
 
     private static Link parseLinkHeader(String rawHeader) {
-        Pattern pattern = Pattern.compile("\\<(.*)\\>;.*rel=\"(.*)\"");
+        Pattern pattern = Pattern.compile("<(.*)>;.*rel=\"?([^;|,|\"]*)\"?.*");
         Matcher matcher = pattern.matcher(rawHeader);
         if (matcher.matches()) {
             return new DefaultLink(matcher.group(2), matcher.group(1));

--- a/http/http-api/src/test/groovy/com/okta/commons/http/HttpHeadersTest.groovy
+++ b/http/http-api/src/test/groovy/com/okta/commons/http/HttpHeadersTest.groovy
@@ -413,11 +413,16 @@ class HttpHeadersTest {
         def headers = new HttpHeaders()
         headers.add("Link", "<https://example.com/api/v1/users?limit=200>; rel=\"self\"")
         headers.add("Link", "<https://dev-259824.oktapreview.com/api/v1/users?after=200u9wv2af0FYl791n0h7&limit=200>; rel=\"next\"")
+        headers.add("Link", "<meta.rdf>; rel=meta; as=meta")
+        headers.add("Link", "<random.link>;")
+        headers.add("Link", "<https://dev-259824.oktapreview.com/_sec/cp_challenge/sec-3-8.css>; as=style; rel=\"preload\"")
 
         def result = headers.getLinkMap()
         assertThat(result.get("self"), equalToObject("https://example.com/api/v1/users?limit=200"))
         assertThat(result.get("next"), equalToObject("https://dev-259824.oktapreview.com/api/v1/users?after=200u9wv2af0FYl791n0h7&limit=200"))
-        assertThat(result, aMapWithSize(2))
+        assertThat(result.get("meta"), equalToObject("meta.rdf"))
+        assertThat(result.get("preload"), equalToObject("https://dev-259824.oktapreview.com/_sec/cp_challenge/sec-3-8.css"))
+        assertThat(result, aMapWithSize(4))
     }
 
     @Test


### PR DESCRIPTION
Customers using akamai will have a link header in http headers. Updating regex logic to match the expected behaviours.

Resolve: [OKTA-566821](https://oktainc.atlassian.net/browse/OKTA-566821)

Reviewers:
@yujiecheng-okta @arvindkrishnakumar-okta @bdemers 