### PR TITLE
Upgrade parent pom to 27 and remove owasp dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>24</version>
+        <version>27</version>
     </parent>
 
     <groupId>com.okta.commons</groupId>
@@ -197,16 +197,6 @@
                             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                             <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
                         </parameter>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>8.0.1</version>
-                    <configuration>
-                        <suppressionFile>${root.dir}/src/owasp/owasp-suppression.xml</suppressionFile>
-                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
-                        <name>OWASP Dependency Check</name>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
- Upgrade okta-java-parent from 24 to 27
- owasp plugin is pulled in from okta-java-parent project and therefore there is no need to explicitly define it here again.