### PR TITLE
Bump org.testng:testng from 7.5.1 to 7.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,6 @@ aliases:
 
 jobs:
 
-  jdk8:
-    docker:
-      - image: cimg/openjdk:8.0.322
-    environment:
-        JVM_OPTS: -Xmx3200m
-    steps: *build_steps
-  
   jdk11:
     docker:
       - image: cimg/openjdk:11.0.13
@@ -56,7 +49,6 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - jdk8
       - jdk11
       - jdk17
       - jdk21

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Support](https://img.shields.io/badge/support-Developer%20Forum-blue.svg)][devforum]
 <!-- [![API Reference](https://img.shields.io/badge/docs-reference-lightgrey.svg)][javadocs] -->
-[![Build Status](https://travis-ci.com/okta/okta-commons-java.svg?branch=master)](https://travis-ci.com/okta/okta-commons-java)
 
 Okta Commons Java
 =================
 
 The Okta Commons Java project contains common modules use across Okta Java ecosystem such as Okta specific configuration validation.
+
+## Prerequisites
+
+Java 11 or later
 
 ## Building the Project
 

--- a/config-check/pom.xml
+++ b/config-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.commons</groupId>
         <artifactId>okta-commons-root</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-config-check</artifactId>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.commons</groupId>
         <artifactId>okta-commons-root</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-commons-coverage</artifactId>

--- a/http/http-api/pom.xml
+++ b/http/http-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.commons</groupId>
         <artifactId>okta-commons-root</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/http/httpclient/pom.xml
+++ b/http/httpclient/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.commons</groupId>
         <artifactId>okta-commons-root</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/http/okhttp/pom.xml
+++ b/http/okhttp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.commons</groupId>
         <artifactId>okta-commons-root</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lang/pom.xml
+++ b/lang/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.commons</groupId>
         <artifactId>okta-commons-root</artifactId>
-        <version>1.3.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-commons-lang</artifactId>

--- a/lang/src/test/groovy/com/okta/commons/lang/ApplicationInfoTest.groovy
+++ b/lang/src/test/groovy/com/okta/commons/lang/ApplicationInfoTest.groovy
@@ -42,7 +42,7 @@ class ApplicationInfoTest {
 
         def info = appInfo.getFullEntryStringUsingManifest(Test.class.getName(), "testng")
         assertThat info.name, is("testng")
-        assertThat info.version, is("7.5.1") // tied to version in pom.xml
+        assertThat info.version, is("7.10.2") // tied to version in pom.xml
 
         info = appInfo.getFullEntryStringUsingManifest(Mockito.class.getName(), "mockito")
         assertThat info.name, is("mockito")

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <github.slug>okta/okta-commons-java</github.slug>
         <okta.commons.previousVersion>1.3.4</okta.commons.previousVersion>
         <kotlin.lib.version>2.0.0</kotlin.lib.version>
-        <testng.version>7.5.1</testng.version>
+        <testng.version>7.10.2</testng.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.okta.commons</groupId>
     <artifactId>okta-commons-root</artifactId>
-    <version>1.3.7-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Okta Commons</name>
@@ -56,27 +56,27 @@
             <dependency>
                 <groupId>com.okta.commons</groupId>
                 <artifactId>okta-commons-lang</artifactId>
-                <version>1.3.7-SNAPSHOT</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.commons</groupId>
                 <artifactId>okta-config-check</artifactId>
-                <version>1.3.7-SNAPSHOT</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.commons</groupId>
                 <artifactId>okta-http-api</artifactId>
-                <version>1.3.7-SNAPSHOT</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.commons</groupId>
                 <artifactId>okta-http-okhttp</artifactId>
-                <version>1.3.7-SNAPSHOT</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.commons</groupId>
                 <artifactId>okta-http-httpclient</artifactId>
-                <version>1.3.7-SNAPSHOT</version>
+                <version>2.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- Upgrade testng from 7.5.1 to 7.10.2
- Updated CCI to remove JDK8 (we need Java 11 or later from versions 2.x onwards - noted this in README)