### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/http/http-api/pom.xml
+++ b/http/http-api/pom.xml
@@ -45,11 +45,11 @@
 
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart</artifactId>
+            <artifactId>ayza</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
 
         <!-- test libs -->

--- a/http/httpclient/pom.xml
+++ b/http/httpclient/pom.xml
@@ -75,7 +75,7 @@
         <!-- https://mvnrepository.com/artifact/com.github.j3t/ssl-utils -->
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-apache4</artifactId>
+            <artifactId>ayza-for-apache4</artifactId>
         </dependency>
         <dependency>
             <!-- compile time annotation processor -->

--- a/http/okhttp/pom.xml
+++ b/http/okhttp/pom.xml
@@ -54,11 +54,11 @@
 
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart</artifactId>
+            <artifactId>ayza</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <github.slug>okta/okta-commons-java</github.slug>
         <okta.commons.previousVersion>2.0.1</okta.commons.previousVersion>
         <kotlin.lib.version>2.2.0</kotlin.lib.version>
-        <sslcontext.kickstart.version>9.1.0</sslcontext.kickstart.version>
+        <ayza.version>10.0.0</ayza.version>
         <testng.version>7.10.2</testng.version>
     </properties>
 
@@ -104,18 +104,18 @@
 
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart</artifactId>
-                <version>${sslcontext.kickstart.version}</version>
+                <artifactId>ayza</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-pem</artifactId>
-                <version>${sslcontext.kickstart.version}</version>
+                <artifactId>ayza-for-pem</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-apache4</artifactId>
-                <version>${sslcontext.kickstart.version}</version>
+                <artifactId>ayza-for-apache4</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <!-- compile time annotation processor -->


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience