### PR TITLE
TG1-TLD update changes - Add new TLDs to URL validator

### DIFF
--- a/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
+++ b/config-check/src/main/java/com/okta/commons/configcheck/ConfigurationValidator.java
@@ -40,11 +40,15 @@ public final class ConfigurationValidator {
     /**
      * Asserts the {@code url} is a well formed HTTPS URL and does not contain common typos.  The checks include:
      * <ul>
-     *     <li>Contains {yourOktaDomain}</li>
-     *     <li>Hostname ends with .com.com</li>
-     *     <li>Contains -admin.okta.com</li>
-     *     <li>Contains -admin.oktapreview.com</li>
-     *     <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains {yourOktaDomain}</li>
+     * <li>Hostname ends with .com.com</li>
+     * <li>Contains -admin.okta.com</li>
+     * <li>Contains -admin.oktapreview.com</li>
+     * <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains -admin.okta-gov.com</li>
+     * <li>Contains -admin.okta.mil</li>
+     * <li>Contains -admin.okta-miltest.com</li>
+     * <li>Contains -admin.trex-gov.com</li>
      * </ul>
      *
      * @param url The url to be validated
@@ -56,11 +60,15 @@ public final class ConfigurationValidator {
 
     /** Asserts the {@code url} is a well formed HTTPS URL and does not contain common typos.  The checks include:
      * <ul>
-     *     <li>Contains {yourOktaDomain}</li>
-     *     <li>Hostname ends with .com.com</li>
-     *     <li>Contains -admin.okta.com</li>
-     *     <li>Contains -admin.oktapreview.com</li>
-     *     <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains {yourOktaDomain}</li>
+     * <li>Hostname ends with .com.com</li>
+     * <li>Contains -admin.okta.com</li>
+     * <li>Contains -admin.oktapreview.com</li>
+     * <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains -admin.okta-gov.com</li>
+     * <li>Contains -admin.okta.mil</li>
+     * <li>Contains -admin.okta-miltest.com</li>
+     * <li>Contains -admin.trex-gov.com</li>
      * </ul>
      *
      * @param url The url to be validated
@@ -78,11 +86,15 @@ public final class ConfigurationValidator {
      * Returns a {@link ValidationResponse} checking to make sure the {@code url} is a well formed HTTPS URL and does
      * not contain common typos.  The checks include:
      * <ul>
-     *     <li>Contains {yourOktaDomain}</li>
-     *     <li>Hostname ends with .com.com</li>
-     *     <li>Contains -admin.okta.com</li>
-     *     <li>Contains -admin.oktapreview.com</li>
-     *     <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains {yourOktaDomain}</li>
+     * <li>Hostname ends with .com.com</li>
+     * <li>Contains -admin.okta.com</li>
+     * <li>Contains -admin.oktapreview.com</li>
+     * <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains -admin.okta-gov.com</li>
+     * <li>Contains -admin.okta.mil</li>
+     * <li>Contains -admin.okta-miltest.com</li>
+     * <li>Contains -admin.trex-gov.com</li>
      * </ul>
      *
      * @param url The url to be validated
@@ -96,13 +108,17 @@ public final class ConfigurationValidator {
      * Returns a {@link ValidationResponse} checking to make sure the {@code url} is a well formed HTTPS URL and does
      * not contain common typos.  The checks include:
      * <ul>
-     *     <li>Contains {yourOktaDomain}</li>
-     *     <li>Hostname ends with .com.com</li>
-     *     <li>Contains -admin.okta.com</li>
-     *     <li>Contains -admin.oktapreview.com</li>
-     *     <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains {yourOktaDomain}</li>
+     * <li>Hostname ends with .com.com</li>
+     * <li>Contains -admin.okta.com</li>
+     * <li>Contains -admin.oktapreview.com</li>
+     * <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains -admin.okta-gov.com</li>
+     * <li>Contains -admin.okta.mil</li>
+     * <li>Contains -admin.okta-miltest.com</li>
+     * <li>Contains -admin.trex-gov.com</li>
      * </ul>
-     *      *
+     * *
      * @param url The url to be validated
      * @param allowNonHttpsForTesting Allow orgUrl to be non-https, likely used for testing.
      * @return a ValidationResponse containing the validation status and message (when invalid)
@@ -145,11 +161,15 @@ public final class ConfigurationValidator {
     /**
      * Asserts the {@code url} is a well formed HTTPS URL and does not contain common typos.  The checks include:
      * <ul>
-     *     <li>Contains {yourOktaDomain}</li>
-     *     <li>Hostname ends with .com.com</li>
-     *     <li>Contains -admin.okta.com</li>
-     *     <li>Contains -admin.oktapreview.com</li>
-     *     <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains {yourOktaDomain}</li>
+     * <li>Hostname ends with .com.com</li>
+     * <li>Contains -admin.okta.com</li>
+     * <li>Contains -admin.oktapreview.com</li>
+     * <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains -admin.okta-gov.com</li>
+     * <li>Contains -admin.okta.mil</li>
+     * <li>Contains -admin.okta-miltest.com</li>
+     * <li>Contains -admin.trex-gov.com</li>
      * </ul>
      *
      * @param url The url to be validated
@@ -163,11 +183,15 @@ public final class ConfigurationValidator {
      * Returns a {@link ValidationResponse} checking the {@code url} is a well formed HTTPS URL and
      * does not contain common typos.  The checks include:
      * <ul>
-     *     <li>Contains {yourOktaDomain}</li>
-     *     <li>Hostname ends with .com.com</li>
-     *     <li>Contains -admin.okta.com</li>
-     *     <li>Contains -admin.oktapreview.com</li>
-     *     <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains {yourOktaDomain}</li>
+     * <li>Hostname ends with .com.com</li>
+     * <li>Contains -admin.okta.com</li>
+     * <li>Contains -admin.oktapreview.com</li>
+     * <li>Contains -admin.okta-emea.com</li>
+     * <li>Contains -admin.okta-gov.com</li>
+     * <li>Contains -admin.okta.mil</li>
+     * <li>Contains -admin.okta-miltest.com</li>
+     * <li>Contains -admin.trex-gov.com</li>
      * </ul>
      *
      * @param url The url to be validated
@@ -253,13 +277,17 @@ public final class ConfigurationValidator {
                 } else if (host.endsWith(".com.com")){
                     response.setMessage(formattedErrorMessage(keyPrefix + ".invalid", url));
                 } else if (host.endsWith("-admin.okta.com")
-                        || host.endsWith("-admin.oktapreview.com")
-                        || host.endsWith("-admin.okta-emea.com")){
-                        response.setMessage(formattedErrorMessage(keyPrefix + ".containsAdmin", url));
+                    || host.endsWith("-admin.oktapreview.com")
+                    || host.endsWith("-admin.okta-emea.com")
+                    || host.endsWith("-admin.okta-gov.com")
+                    || host.endsWith("-admin.okta.mil")
+                    || host.endsWith("-admin.okta-miltest.com")
+                    || host.endsWith("-admin.trex-gov.com")) {
+                    response.setMessage(formattedErrorMessage(keyPrefix + ".containsAdmin", url));
                 }
             } catch (MalformedURLException e) {
                 response.setMessage(formattedErrorMessage(keyPrefix + ".invalid", url))
-                        .setException(e);
+                    .setException(e);
             }
         }
 

--- a/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
+++ b/config-check/src/test/groovy/com/okta/commons/configcheck/ConfigurationValidatorTest.groovy
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.containsString
  * Tests for {link ConfigurationValidator}.
  */
 class ConfigurationValidatorTest {
-    
+
     @Test
     void nullBaseUrl() {
         def e = expect {ConfigurationValidator.assertOrgUrl(null)}
@@ -81,6 +81,18 @@ class ConfigurationValidatorTest {
         assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
 
          e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.okta-emea.com")}
+        assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.okta-gov.com")}
+        assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.okta.mil")}
+        assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.okta-miltest.com")}
+        assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertOrgUrl("https://example-admin.trex-gov.com")}
         assertThat(e.message, containsString("Your Okta domain should not contain -admin"))
     }
 
@@ -160,6 +172,18 @@ class ConfigurationValidatorTest {
 
         e = expect {ConfigurationValidator.assertIssuer("https://example-aDmIn.okTa-emea.com/oauth/default")}
         assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta-gov.com/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta.mil/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://example-admin.okta-miltest.com/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
+
+        e = expect {ConfigurationValidator.assertIssuer("https://example-admin.trex-gov.com/oauth/default")}
+        assertThat(e.message, containsString("Your Okta Issuer URL should not contain -admin"))
     }
 
     @Test
@@ -234,7 +258,7 @@ class ConfigurationValidatorTest {
         // just make sure it doesn't throw
         ConfigurationValidator.assertClientSecret("some-other-text")
     }
-    
+
     static def expect = { Closure callMe ->
         try {
             callMe.call()
@@ -246,5 +270,5 @@ class ConfigurationValidatorTest {
             return e
         }
     }
-    
+
 }


### PR DESCRIPTION
This PR updates the ConfigurationValidator to recognize new Okta top-level domains (TLDs) as part of the TG1 TLD Update initiative.

The validation logic in ConfigurationValidator has been updated to include checks for new domains required for government and test environments. Specifically, it adds logic to prevent the misuse of -admin subdomains for these new TLDs.

